### PR TITLE
MAINTAINER instruction deprecated, moved to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # https://github.com/phusion/passenger-docker#using
 FROM phusion/passenger-customizable:1.0.1
 
-MAINTAINER Materials Cloud <developers@materialscloud.org>
+LABEL maintainer="Materials Cloud <developers@materialscloud.org>"
 
 # Everything will be run as root
 USER root


### PR DESCRIPTION
The `MAINTAINER` instruction is deprecated according to the [Docker documentation](https://docs.docker.com/engine/reference/builder/#copy). Moved it, as recommended, to the label. 