### PR TITLE
Use qe-tools v2.0.0rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   precommit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
           pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
   dockertests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ def process_structure():
     # If we are here, the file was retrieved.
     # It will contain a tuple of length three, with:
     # - the 3x3 unit cell (in angstrom)
-    # - a Nx3 list of atomic coordinates (in angstrom)
+    # - a Nx3 list of atomic coordinates (in fractional coordinates)
     # - a list of integer atomic numbers of length N
 
     # As an example, we just create a string representation of the JSON

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyyaml==5.3.1
 
 # The following are needed for the structure importer
 ase==3.20.1
-qe-tools==1.1.4
+qe-tools==2.0.0rc1
 pymatgen==2020.10.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyyaml==5.3.1
 
 # The following are needed for the structure importer
 ase==3.20.1
-qe-tools==2.0.0rc1
+qe-tools==2.0.0rc2
 pymatgen==2020.10.20

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy>=1.16",
         "pyyaml>=5.3.1",
         "ase>=3",
-        "qe-tools==2.0.0rc1",
+        "qe-tools==2.0.0rc2",
         "pymatgen>=2019.7.2",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy>=1.16",
         "pyyaml>=5.3.1",
         "ase>=3",
-        "qe-tools>=1.1.4",
+        "qe-tools==2.0.0rc1",
         "pymatgen>=2019.7.2",
     ],
     extras_require={

--- a/tools_barebone/__init__.py
+++ b/tools_barebone/__init__.py
@@ -6,7 +6,7 @@ from functools import wraps, update_wrapper
 import flask
 
 # tools-barebone version
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # This flag changes the style of the webpage (CSS, etc.)
 # and decides whether some of the headers (e.g. the App title) and the

--- a/tools_barebone/structure_importers/__init__.py
+++ b/tools_barebone/structure_importers/__init__.py
@@ -223,8 +223,9 @@ def get_structure_tuple(  # pylint: disable=too-many-locals
         pmgstructure = PMGCifParser(fileobject).get_structures()[0]
         return tuple_from_pymatgen(pmgstructure)
     if fileformat == "qeinp-qetools":
-        pwfile = qe_tools.PwInputFile(fileobject)
-        pwparsed = pwfile.get_structure_from_qeinput()
+        fileobject.seek(0)
+        pwfile = qe_tools.parsers.PwInputFile(fileobject.read())
+        pwparsed = pwfile.structure
 
         cell = pwparsed["cell"]
         rel_position = np.dot(pwparsed["positions"], np.linalg.inv(cell)).tolist()

--- a/tools_barebone/structure_importers/__init__.py
+++ b/tools_barebone/structure_importers/__init__.py
@@ -224,7 +224,9 @@ def get_structure_tuple(  # pylint: disable=too-many-locals
         return tuple_from_pymatgen(pmgstructure)
     if fileformat == "qeinp-qetools":
         fileobject.seek(0)
-        pwfile = qe_tools.parsers.PwInputFile(fileobject.read())
+        pwfile = qe_tools.parsers.PwInputFile(
+            fileobject.read(), validate_species_names=True
+        )
         pwparsed = pwfile.structure
 
         cell = pwparsed["cell"]


### PR DESCRIPTION
The package now installs `qe-tools 2.0.0rc1` and the code to parse QE input files has been updated according to the changes in the qe-tools package.
The reason that pushed this is that `aiida-quantumespresso v3.3.0` (used in tools-qe-input-generator) installs `qe-tools 2.0.0rc1`.