### PR TITLE
Remove apache pid file

### DIFF
--- a/.docker_files/apache_run.sh
+++ b/.docker_files/apache_run.sh
@@ -15,7 +15,8 @@ then
 fi
 
 ## Delete PID files if exists
-## For now I keep commented, will see if needed
-# rm -f /var/run/apache2/apache2.pid
+## A leftover apache.pid file after a reboot prevents the
+## container to start (see issue #26)
+rm -f /var/run/apache2/apache2.pid
 
 exec apache2 -D FOREGROUND

--- a/tools_barebone/__init__.py
+++ b/tools_barebone/__init__.py
@@ -6,7 +6,7 @@ from functools import wraps, update_wrapper
 import flask
 
 # tools-barebone version
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 # This flag changes the style of the webpage (CSS, etc.)
 # and decides whether some of the headers (e.g. the App title) and the


### PR DESCRIPTION
Solves issue #26.

After a hard reboot of the host machine, the apache pid file is not removed and this prevents a restart.
Here we remove the apache pid file at container start, just before launching the apache service.